### PR TITLE
Add new command line '--filetype' option.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,6 +44,9 @@ Features
 * Doesn't run the tests multiple times if you're using vim, Unlike the similar
   plugin `nose-watch`.
 
+* Specify additional filetypes to watch using the command line argument
+  `--filetype`.
+
 
 Installation
 ------------
@@ -58,3 +61,5 @@ Usage
 .. code-block:: bash
 
     nosetests --with-watcher
+
+    nosetests --with-watcher --filetype .txt

--- a/nose_watcher/nose_watcher.py
+++ b/nose_watcher/nose_watcher.py
@@ -47,11 +47,13 @@ class WatcherPlugin(Plugin):
         return args
 
     def options(self, parser, env):
+        """ Configure with command line option '--filetype'. """
         Plugin.options(self, parser, env)
         parser.add_option('--filetype', action='append',
                           help='Specify additional filetypes to monitor.')
 
     def configure(self, options, conf):
+        """ Get filetype option to specify additional filetypes to watch. """
         Plugin.configure(self, options, conf)
         if options.filetype:
             self.filetypes = tuple(list(self.python_files) + options.filetype)

--- a/nose_watcher/nose_watcher.py
+++ b/nose_watcher/nose_watcher.py
@@ -27,12 +27,16 @@ class WatcherPlugin(Plugin):
     python_files = ('.py', '.pyx')
     testing = False
 
+    def __init__(self):
+        Plugin.__init__(self)
+        self.filetypes = tuple(self.python_files)
+
     def call(self):
         args = self.get_commandline_arguments()
         Popen(args).wait()
 
     def check_files(self, files):
-        return any(f.endswith(self.python_files) for f in files)
+        return any(f.endswith(self.filetypes) for f in files)
 
     def get_commandline_arguments(self, argv=None):
         if argv is None:
@@ -41,6 +45,16 @@ class WatcherPlugin(Plugin):
         # The arguments we want to run nose with again.
         args = [a for a in argv if a != '--with-%s' % PLUGIN_NAME]
         return args
+
+    def options(self, parser, env):
+        Plugin.options(self, parser, env)
+        parser.add_option('--filetype', action='append',
+                          help='Specify additional filetypes to monitor.')
+
+    def configure(self, options, conf):
+        Plugin.configure(self, options, conf)
+        if options.filetype:
+            self.filetypes = tuple(list(self.python_files) + options.filetype)
 
     def print_status(self):  # pragma:nocover
         print('Watching for changes...\n')


### PR DESCRIPTION
The new option lets someone specify what file types to watch in additional to the default '.py', '.pyx'. By specifying the option multiple times, multiple file types can be chosen.

    nosetests --with-watcher --filetype .txt
    nosetests --with-watcher --filetype .js --filetype .txt

A bit clumsy maybe, but pretty useful when your code is dependent on non-python files!